### PR TITLE
Mpharoah/more tests

### DIFF
--- a/test/d2l-resize-aware.html
+++ b/test/d2l-resize-aware.html
@@ -28,30 +28,29 @@
 			</template>
 		</test-fixture>
 		<script type="module">
+import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 describe('<d2l-resize-aware>', function() {
 
 	let resizeEventFired = false;
 	let component;
 	
 	const runTest = function( expectEvent, done, action ) {
-		component.addEventListener( 'd2l-resize-aware-resized', function() {
-			resizeEventFired = true;
+		resizeEventFired = false;
+		action();
+		afterNextRender( component, function() {
+			assert.equal( !!resizeEventFired, !!expectEvent );
+			done();
 		});
-		
-		setTimeout( function() {
-			resizeEventFired = false;
-			action();
-			setTimeout( function() {
-				assert.equal( !!resizeEventFired, !!expectEvent );
-				done();
-			}, 250 );
-		}, 0 );
 	};
 
 	describe('contains native HTML elements', function() {
 
-		beforeEach(function() {
+		beforeEach(function(done) {
 			component = fixture('NativeElementsFixture');
+			component.addEventListener( 'd2l-resize-aware-resized', function() {
+				resizeEventFired = true;
+			});
+			afterNextRender(component,done);
 		});
 
 		it('element resized', function( done ) {

--- a/test/d2l-resize-aware.html
+++ b/test/d2l-resize-aware.html
@@ -27,8 +27,39 @@
 				</d2l-resize-aware>
 			</template>
 		</test-fixture>
+		
+		<test-fixture id="SimpleComponentFixture">
+			<template strip-whitespace>
+				<d2l-resize-aware>
+					<test-component-simple></test-component-simple>
+				</d2l-resize-aware>
+			</template>
+		</test-fixture>
+		
+		<test-fixture id="SlottedComponentFixture">
+			<template strip-whitespace>
+				<d2l-resize-aware>
+					<test-component-slotted>
+						<test-component-simple></test-component-simple>
+					</test-component-slotted>
+				</d2l-resize-aware>
+			</template>
+		</test-fixture>
+		
+		<test-fixture id="NestedComponentFixture">
+			<template strip-whitespace>
+				<d2l-resize-aware>
+					<test-component-nested></test-component-nested>
+				</d2l-resize-aware>
+			</template>
+		</test-fixture>
+		
 		<script type="module">
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
+import SimpleTestComponents from './test-component-simple.js';
+import NestedTestComponents from './test-component-nested.js';
+import './test-component-slotted.js';
+
 describe('<d2l-resize-aware>', function() {
 
 	let resizeEventFired = false;
@@ -42,16 +73,20 @@ describe('<d2l-resize-aware>', function() {
 			done();
 		});
 	};
-
-	describe('contains native HTML elements', function() {
-
-		beforeEach(function(done) {
-			component = fixture('NativeElementsFixture');
+	
+	const setup = function( testFixture ) {
+		return function(done) {
+			component = fixture( testFixture );
 			component.addEventListener( 'd2l-resize-aware-resized', function() {
 				resizeEventFired = true;
 			});
 			afterNextRender(component,done);
-		});
+		};
+	};
+
+	describe('contains native HTML elements', function() {
+
+		beforeEach( setup( 'NativeElementsFixture' ) );
 
 		it('element resized', function( done ) {
 			runTest( true, done, function() {
@@ -79,8 +114,94 @@ describe('<d2l-resize-aware>', function() {
 
 	});
 	
-	//TODO: add more tests where the resize-element contains webcomponent children
+	describe('contains simple webcomponent', function() {
 
+		beforeEach( setup( 'SimpleComponentFixture' ) );
+
+		it('webcomponent resized', function( done ) {
+			runTest( true, done, function() {
+				SimpleTestComponents[0].resizeDiv( '200px', '600px' );
+			});
+		});
+		
+		it('control test', function( done ) {
+			runTest( false, done, () => null );
+		});
+
+	});
+	
+	describe('contains slotted webcomponent', function() {
+
+		beforeEach( setup( 'SlottedComponentFixture' ) );
+
+		it('webcomponent resized', function( done ) {
+			runTest( true, done, function() {
+				SimpleTestComponents[0].resizeDiv( '200px', '600px' );
+			});
+		});
+		
+		it('element added to slot', function( done ) {
+			runTest( true, done, function() {
+				let textDiv = document.createElement( 'div' );
+				textDiv.textContent = 'Text.';
+				component.querySelector( 'test-component-slotted' ).appendChild( textDiv );
+			});
+		});
+		
+		it('element removed from slot', function( done ) {
+			runTest( true, done, function() {
+				const slottedComponent = component.querySelector( 'test-component-slotted' );
+				slottedComponent.removeChild( slottedComponent.querySelector( 'test-component-simple' ) );
+			});
+		});
+		
+		
+		it('control test', function( done ) {
+			runTest( false, done, () => null );
+		});
+
+	});
+	
+	describe('contains nested webcomponent', function() {
+
+		beforeEach( setup( 'NestedComponentFixture' ) );
+
+		it('nested webcomponent resized', function( done ) {
+			runTest( true, done, function() {
+				SimpleTestComponents[0].resizeDiv( '200px', '600px' );
+			});
+		});
+		
+		it('nested webcomponent removed', function( done ) {
+			runTest( true, done, function() {
+				NestedTestComponents[0].removeChildComponent();
+			});
+		});
+		
+		it('nested webcomponent added', function( done ) {
+			runTest( true, done, function() {
+				NestedTestComponents[0].addChildComponent();
+			});
+		});
+		
+		it('element resized after being added to component', function( done ) {
+			NestedTestComponents[0].addChildComponent();
+			afterNextRender( NestedTestComponents[0], function() {
+				resizeEventFired = false;
+				SimpleTestComponents[1].resizeDiv( '200px', '600px' );
+				afterNextRender( NestedTestComponents[0], function() {
+					assert.equal( !!resizeEventFired, true );
+					done();
+				});
+			});
+		});
+		
+		it('control test', function( done ) {
+			runTest( false, done, () => null );
+		});
+
+	});
+	
 });
 </script>
 	</body>

--- a/test/test-component-nested.js
+++ b/test/test-component-nested.js
@@ -1,0 +1,63 @@
+import { PolymerElement, html } from '@polymer/polymer';
+import '@polymer/polymer/lib/elements/dom-if.js';
+import './test-component-simple.js';
+
+const _testComponents = [];
+
+class NestedTestComponent extends PolymerElement {
+	
+	static get is() {
+		return 'test-component-nested';
+	}
+	
+	static get template() {
+		const template = html`
+			<template is="dom-if" if="[[_hasChild1]]" restamp>
+				<test-component-simple></test-component-simple>
+			</template>
+			<template is="dom-if" if="[[_hasChild2]]" restamp>
+				<test-component-simple></test-component-simple>
+			</template>
+		`;
+		template.setAttribute('strip-whitespace', true);
+		return template;
+	}
+	
+	static get properties() {
+		return {
+			'_hasChild1': {
+				type: Boolean,
+				value: true
+			},
+			'_hasChild2': {
+				type: Boolean,
+				value: false
+			}
+		};
+	}
+	
+	connectedCallback() {
+		super.connectedCallback();
+		_testComponents.push( this );
+	}
+	
+	disconnectedCallback() {
+		const i = _testComponents.indexOf( this );
+		if( i >= 0 ) {
+			_testComponents.splice( i, 1 );
+		}
+	}
+	
+	addChildComponent() {
+		this.set( '_hasChild2', true );
+	}
+	
+	removeChildComponent() {
+		this.set( '_hasChild1', false );
+	}
+	
+}
+
+customElements.define( NestedTestComponent.is, NestedTestComponent );
+
+export default _testComponents;

--- a/test/test-component-simple.js
+++ b/test/test-component-simple.js
@@ -1,0 +1,51 @@
+import { PolymerElement, html } from '@polymer/polymer';
+
+const _testComponents = [];
+
+class SimpleTestComponent extends PolymerElement {
+	
+	static get is() {
+		return 'test-component-simple';
+	}
+	
+	static get template() {
+		const template = html`
+			<style>
+				#div {
+					background-color: grey;
+					width: 400px;
+					height: 200px;
+				}
+			</style>
+			<div id="div"></div>
+		`;
+		template.setAttribute('strip-whitespace', true);
+		return template;
+	}
+	
+	static get properties() {
+		return {}
+	}
+	
+	connectedCallback() {
+		super.connectedCallback();
+		_testComponents.push( this );
+	}
+	
+	disconnectedCallback() {
+		const i = _testComponents.indexOf( this );
+		if( i >= 0 ) {
+			_testComponents.splice( i, 1 );
+		}
+	}
+	
+	resizeDiv( width, height ) {
+		this.$.div.style.width = width;
+		this.$.div.style.height = height;
+	}
+	
+}
+
+customElements.define( SimpleTestComponent.is, SimpleTestComponent );
+
+export default _testComponents;

--- a/test/test-component-slotted.js
+++ b/test/test-component-slotted.js
@@ -1,0 +1,19 @@
+import { PolymerElement, html } from '@polymer/polymer';
+
+class SlottedTestComponent extends PolymerElement {
+	
+	static get is() {
+		return 'test-component-slotted';
+	}
+	
+	static get template() {
+		return html`<slot></slot>`;
+	}
+	
+	static get properties() {
+		return {}
+	}
+	
+}
+
+customElements.define( SlottedTestComponent.is, SlottedTestComponent );


### PR DESCRIPTION
Added more tests to the `<resize-aware>` component.

@dbatiste 
Interestingly, it seems like Chrome (which just uses the native ResizeObserver) fails to detect resizes that happen as a result of removing an element. ( https://github.com/BrightspaceUI/resize-aware/issues/4 )

Because of this, we might need to use the recursive Shadow DOM observer strategy even on Chrome, but I'll look into it. Right now, I'm not making any changes other than adding the tests. They pass on Firefox, IE11, and Edge, but 3 tests fail on Chrome