### PR TITLE
Workaround browser bug with Chrome's implementation of ResizeObserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ The latest version of all major browsers (including Internet Explorer) are suppo
 
 There are 3 different implemenations that will be used depending on the browser, plus an additional workaround for Safari:
   - **Browser natively supports ResizeObserver _(Chrome, Chromium)_**  
-    Simply use the native ResizeObserver.
+    ~Simply use the native ResizeObserver.~  
+	Due to a bug ( [#4](https://github.com/BrightspaceUI/resize-aware/issues/4) ) in Chrome's implementation of `ResizeObserver`, it currently uses the same fallback as Firefox and Safari.
   - **Browser supports neither ResizeObserver nor native Shadow DOM, using the Shady DOM polyfill instead _(Edge, IE11)_**  
     Uses a single MutationObserver plus a `resize` and `transitionend` event handler on the window, and relies on the shady DOM polyfill to detect changes in the shady DOM of child webcomponents
   - **Browser supports native Shadow DOM, but not ResizeObserver _(Firefox, Safari)_**  

--- a/d2l-resize-aware.js
+++ b/d2l-resize-aware.js
@@ -40,9 +40,15 @@ class D2LResizeAware extends PolymerElement {
 	constructor() {
 		super();
 		
-		this._hasNativeResizeObserver =
-			window.ResizeObserver &&
-			window.ResizeObserver.toString().indexOf( '[native code]' ) >= 0;
+		/*
+		Chrome is currently the only browser to support ResizeObserver, however its
+		implementation is broken and does not detect resizes that occur as a result
+		of removing an element from the DOM. Until this is fixed, we cannot rely on
+		the native ResizeObserver for correct functionality.
+		*/
+		this._hasNativeResizeObserver = false;
+			//window.ResizeObserver &&
+			//window.ResizeObserver.toString().indexOf( '[native code]' ) >= 0;
 		
 		this._isSafari =
 			window.navigator.userAgent.indexOf( 'Safari/' ) >= 0 &&

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "d2l-resize-aware",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "A Polymer 3 compatible method to detect changes in an element's size and/or position",
 	"main": "d2l-resize-aware.js",
 	"scripts": {


### PR DESCRIPTION
Use the recursive mutation observer strategy for Chrome, as its ResizeObserver implementation is currently defective (fixes #4)

Fixes the issue is discovered in https://github.com/BrightspaceUI/resize-aware/pull/2