### PR TITLE
Better native function check

### DIFF
--- a/d2l-resize-aware.js
+++ b/d2l-resize-aware.js
@@ -39,12 +39,8 @@ class D2LResizeAware extends PolymerElement {
 		
 		this._hasNativeResizeObserver =
 			window.ResizeObserver &&
-			window.ResizeObserver.toString().indexOf( '[native code]' ) >= 0;
+			/^\s*function ResizeObserver\(\) \{\s+\[native code\]\s+\}\s*$/.test( window.ResizeObserver.toString() );
 		
-		this._isSafari =
-			window.navigator.userAgent.indexOf( 'Safari/' ) >= 0 &&
-			window.navigator.userAgent.indexOf( 'Chrome/' ) === -1;
-			
 		this._onPossibleResize = this._onPossibleResize.bind( this );
 	}
 	

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "d2l-resize-aware",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "A Polymer 3 compatible ResizeObserver polyfill and utility component",
 	"main": "d2l-resize-aware.js",
 	"scripts": {

--- a/resize-observer-polyfill.js
+++ b/resize-observer-polyfill.js
@@ -1,6 +1,9 @@
 import { ResizeObserverPolyfill, ResizeObserverEntryPolyfill } from './internal/d2l-resize-observer';
 
-if( !window.ResizeObserver || window.ResizeObserver.toString().indexOf( '[native code]' ) < 0 ) {
+if(
+	!window.ResizeObserver ||
+	!/^\s*function ResizeObserver\(\) \{\s+\[native code\]\s+\}\s*$/.test( window.ResizeObserver.toString() )
+) {
 	window.ResizeObserver = ResizeObserverPolyfill;
 	window.ResizeObserverEntry = ResizeObserverEntryPolyfill;
 }


### PR DESCRIPTION
* Fixed check to determine if `ResizeObserver` has a native implementation to avoid false positives
* Removed unused internal property