### PR TITLE
Initial event fix

### DIFF
--- a/internal/d2l-resize-observer.js
+++ b/internal/d2l-resize-observer.js
@@ -141,7 +141,6 @@ const onPossibleResize = function() {
 				const resizeEntry = new ResizeObserverEntryPolyfill();
 				resizeEntry.__target = node;
 				resizeEntry.__contentRect = newContentSize;
-				resizeEntry.__boundingBox = newBoundingClientSize;
 				
 				if( observerMap.has( observer ) ) {
 					observerMap.get( observer ).push( resizeEntry );
@@ -236,7 +235,7 @@ class ResizeObserverEntryPolyfill {
 	get target() { return this.__target; }
 	
 	// extension
-	get boundingBox() { return this.__boundingBox; }
+	get boundingBox() { return getSize( this.__target, true ); }
 }
 
 class ResizeObserverPolyfill {
@@ -257,7 +256,7 @@ class ResizeObserverPolyfill {
 		addListener( node, this );
 		const resizeEntry = new ResizeObserverEntryPolyfill();
 		resizeEntry.__target = node;
-		resizeEntry.__contentRect = getSize( node, this.__fullBoundingBox );
+		resizeEntry.__contentRect = getSize( node, false );
 		this.__callback( [resizeEntry] );
 	}
 	

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "d2l-resize-aware",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"description": "A Polymer 3 compatible ResizeObserver polyfill and utility component",
 	"main": "d2l-resize-aware.js",
 	"scripts": {


### PR DESCRIPTION
Fixed initial resize event when a ResizeObserver begins observing a node to have the correct values