### PR TITLE
feat: CodeArtifact Migration - Phase 1 & Phase 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - main
       - '[0-9]+.x'
       - '[0-9]+.[0-9]+.x'
 permissions:
@@ -26,5 +26,6 @@ jobs:
       - name: Semantic Release
         uses: BrightspaceUI/actions/semantic-release@main
         with:
-          DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{secrets.D2L_GITHUB_TOKEN}}
+          NPM: true
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}            

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# resize-aware
+# @brightspace-ui/resize-aware
 A Polymer 3 compatible solution to reacting to changes in an element's size and/or position.
 Contains a polyfill for `ResizeObserver` that is able to detect changes inside of webcomponents on all supported browsers (Firefox, Chrome/Chromium, Edge, IE11, and Safari).
 
@@ -7,22 +7,22 @@ Contains a polyfill for `ResizeObserver` that is able to detect changes inside o
 #### Global Polyfill
 To use the polyfill, simply import `resize-observer-polyfill.js` into the page:
 ```javascript
-import 'd2l-resize-aware/resize-observer-polyfill.js';
+import '@brightspace-ui/resize-aware/resize-observer-polyfill.js';
 ```
 or
 ```html
-<script type="module" src="d2l-resize-aware/resize-observer-polyfill.js"></script>
+<script type="module" src="@brightspace-ui/resize-aware/resize-observer-polyfill.js"></script>
 ```
 
 #### Module Import
 Alternatively, if you do not wish to alter or define `window.ResizeObserver`, you can instead import the polyfill as an es6 module:
 ```javascript
-import { ResizeObserver } from 'd2l-resize-aware/resize-observer-module.js';
+import { ResizeObserver } from '@brightspace-ui/resize-aware/resize-observer-module.js';
 ```
 
 Additionally, a separate class is provided that is capable to detecting changes in position as well as size, and checks the client bounding box (as returned by `getBoundingClientRect()`) rather than its content box.
 ```javascript
-import { BoundingBoxObserver } from 'd2l-resize-aware/resize-observer-module.js';
+import { BoundingBoxObserver } from '@brightspace-ui/resize-aware/resize-observer-module.js';
 ```
 
 ### Web Component

--- a/demo/index.html
+++ b/demo/index.html
@@ -37,7 +37,7 @@
 			<span class="bar" id="width-bar"></span><span id="width-text"></span>
 			<br><br>
 			<d2l-resize-aware id="resize-detector">
-				<d2l-input-textarea value="Type here!"></d2l-input-textarea>
+				<d2l-input-textarea label="type here" value="Type here!"></d2l-input-textarea>
 				<br>
 				<textarea>Resize me!</textarea>
 			</d2l-resize-aware>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "d2l-resize-aware",
+  "name": "@brightspace-ui/resize-aware",
   "version": "1.3.0",
   "main": "d2l-resize-aware.js",
   "scripts": {
@@ -11,8 +11,8 @@
     "format": "npm run format:eslint",
     "format:eslint": "npm run lint:eslint -- --fix",
     "test": "npm run lint && npm run test:local",
-    "test:sauce": "npm run lint && polymer test --skip-plugin sauce",
-    "test:local": "npm run lint && polymer test --skip-plugin local"
+    "test:sauce": "npm run lint && polymer test --skip-plugin local",
+    "test:local": "npm run lint && polymer test --skip-plugin sauce"
   },
   "files": [
     "/internal",
@@ -20,6 +20,9 @@
     "resize-observer-module.js",
     "resize-observer-polyfill.js"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "dependencies": {

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -11,7 +11,7 @@
 				"firefox": [
 					"-headless",
 					"-new-instance",
-					"http://localhost:8081/components/d2l-resize-aware/generated-index.html?cli_browser_id=1"
+					"http://localhost:8081/components/@brightspace-ui/resize-aware/generated-index.html?cli_browser_id=1"
 				]
 			}
 		},


### PR DESCRIPTION
Phase 1:
- [x] Publish to npm
  - Change the name to the new name (found in spreadsheet)
  - Add `publishConfig` and `files` to `package.json`
  - Update the `release.yml` workflow accordingly (will vary depending on release action used)
- [x] Update README
  - Update install instructions and paths if name changed
  - Update `Releases` section to mention it publishes to `npm`

Phase 2:
- [x] Nothing to do (this repo doesn't pull in any other repos we're updating, and can't be moved to node 16 until it stops using `polymer-cli`)
