### PR TITLE
Temporary fix for dependency issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "eslint": "^8",
         "eslint-config-brightspace": "^0.20",
         "lit-analyzer": "^1",
-        "stylelint": "^15"
+        "stylelint": "^15",
+        "typescript": "^5"
       },
       "engines": {
         "npm": ">=9.5.0 <10"
@@ -9180,8 +9181,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.3.tgz",
       "integrity": "sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint": "^8",
     "eslint-config-brightspace": "^0.20",
     "lit-analyzer": "^1",
-    "stylelint": "^15"
+    "stylelint": "^15",
+    "typescript": "^5"
   }
 }


### PR DESCRIPTION
This adds `typescript` as a dev dependency to force resolution of it when doing installs. Since the `typescript` version 5 dependency on the `puppeteer-core` package is optional but the `typescript` version 3 dependency on `lit-analyzer` is not `npm` get's confused when deduping stuff. Once we move away from `lit-analyzer` to the official `@lit-labs/analyzer` (once it's no longer labs) this will fix the issue properly.